### PR TITLE
feat: always use latest FroshPluginUploader

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM php:${PHP_VERSION}-cli-alpine
 
 ARG SHOPWARE_VERSION=dev-master
 ARG TEMPLATE_REPOSITORY=https://github.com/shopware/production
-ARG PLUGIN_UPLOADER_VERSION=0.3.12
 ARG PHP_SCOPER_VERSION=0.14.0
 
 COPY --from=composer:2.0 /usr/bin/composer /usr/bin/composer
@@ -40,7 +39,7 @@ RUN \
         composer clearcache && \
         rm -rf "${SHOPWARE_BUILD_DIR}/custom/plugins" && \
         mkdir -p /plugins && ln -s /plugins "${SHOPWARE_BUILD_DIR}/custom/plugins" && \
-    wget https://github.com/FriendsOfShopware/FroshPluginUploader/releases/download/${PLUGIN_UPLOADER_VERSION}/frosh-plugin-upload.phar -O /opt/bin/plugin-uploader && \
+    wget https://github.com/FriendsOfShopware/FroshPluginUploader/releases/latest/download/frosh-plugin-upload.phar -O /opt/bin/plugin-uploader && \
     wget https://github.com/humbug/php-scoper/releases/download/${PHP_SCOPER_VERSION}/php-scoper.phar -O /opt/bin/php-scoper && \
     chmod +x /opt/bin/plugin-uploader /opt/bin/php-scoper
 


### PR DESCRIPTION
FYI: php-scoper has just pre-releases