### PR TITLE
feat: Add shopware version 6.4.9.0 to github action

### DIFF
--- a/.github/workflows/build-docker-images.yaml
+++ b/.github/workflows/build-docker-images.yaml
@@ -48,6 +48,8 @@ jobs:
             php-version: "8.0"
           - shopware-version: v6.4.8.2
             php-version: "8.0"
+          - shopware-version: v6.4.9.0
+            php-version: "8.0"
           - shopware-version: 6.3
             php-version: "7.4"
           - shopware-version: 6.4


### PR DESCRIPTION
Adding the latest shopware version to the github action to supply the latest image of platform-plugin-dev