### PR TITLE
chore: Add Shopware 6.4.14

### DIFF
--- a/.github/workflows/build-docker-images.yaml
+++ b/.github/workflows/build-docker-images.yaml
@@ -58,6 +58,8 @@ jobs:
             php-version: "8.0"
           - shopware-version: v6.4.13.0
             php-version: "8.0"
+          - shopware-version: v6.4.14.0
+            php-version: "8.0"
           - shopware-version: 6.3
             php-version: "7.4"
           - shopware-version: 6.4


### PR DESCRIPTION
Currently there are not tags available for Shopware 6.4.14.

This PR adds Shopware 6.4.14.0 to the matrix definded in `build-docker-images.yaml`