### PR TITLE
Pin NodeJS version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,13 @@ ARG TEMPLATE_REPOSITORY=https://github.com/shopware/production
 ENV SHOPWARE_BUILD_DIR /opt/shopware
 
 RUN \
+  if echo "${SHOPWARE_VERSION}" | grep -q '^6.4.*'; then \
+      apk add --no-cache --repository="https://dl-cdn.alpinelinux.org/alpine/v3.16/main" 'nodejs=16.17.1-r0' 'npm=8.10.0-r0'; \
+  else \
+      apk add --no-cache npm; \
+  fi
+
+RUN \
     start-mysql && \
     mysql -e "CREATE DATABASE shopware" && \
     mysqladmin --user=root password 'root' && \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -5,7 +5,7 @@ COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr
 
 RUN \
     apk add --no-cache git zip unzip zlib-dev libpng-dev icu-dev libzip-dev bash jq \
-        mysql mysql-client npm python3 make g++ && \
+        mysql mysql-client python3 make g++ && \
     echo 'alias ll="ls -lha"' >> ~/.bashrc && \
     install-php-extensions gd intl pdo_mysql zip xsl pcov redis
 


### PR DESCRIPTION
Since extensions built with NodeJS v18 might be incompatible with a `shopware/administration` or `shopware/storefront` built with NodeJS v16, we'd like to pin the version used in this image, at least for the Shopware v6.4.* images.