### PR TITLE
Remove the composer caret version constraint operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG TEMPLATE_REPOSITORY=https://github.com/shopware/production
 ENV SHOPWARE_BUILD_DIR /opt/shopware
 
 RUN \
-  if echo "${SHOPWARE_VERSION}" | grep -q '^6.4.*'; then \
+  if echo "${SHOPWARE_VERSION}" | grep -q '6.4.*'; then \
       apk add --no-cache --repository="https://dl-cdn.alpinelinux.org/alpine/v3.16/main" 'nodejs=16.17.1-r0' 'npm=8.10.0-r0'; \
   else \
       apk add --no-cache npm; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG TEMPLATE_REPOSITORY=https://github.com/shopware/production
 ENV SHOPWARE_BUILD_DIR /opt/shopware
 
 RUN \
-  if echo "${SHOPWARE_VERSION}" | grep -q '6.4.*'; then \
+  if echo "${SHOPWARE_VERSION}" | grep -q '^v6.4.*'; then \
       apk add --no-cache --repository="https://dl-cdn.alpinelinux.org/alpine/v3.16/main" 'nodejs=16.17.1-r0' 'npm=8.10.0-r0'; \
   else \
       apk add --no-cache npm; \


### PR DESCRIPTION
## Remove the composer caret version constraint operator to match the passed shopware build matrix version string.

As seen in one of the last [runs](https://github.com/FriendsOfShopware/platform-plugin-dev-docker/actions/runs/3898508294/jobs/6657337822#step:6:208) for the shopware version `6.4.17.1` there it downloads and istalls `nodejs-current` with version `18.9.1-r0` instead of nodejs `6.17.1-r0`.

On this [line](https://github.com/FriendsOfShopware/platform-plugin-dev-docker/actions/runs/3898508294/jobs/6657337822#step:6:203) we can see the versions are passed like 
```bash
if echo "v6.4.17.1" | grep -q '^6.4.*'; then
    apk add --no-cache --repository="https://dl-cdn.alpinelinux.org/alpine/v3.16/main" 'nodejs=16.17.1-r0' 'npm=8.10.0-r0';
else
    apk add --no-cache npm;   fi
```

To reproduce it you can check the matching with something like
```bash
# instead of 
# if echo "v6.4.17.1" | grep -q '^6.4.*'; then
if echo "v6.4.17.1" | grep -q '6.4.*'; then
    echo "good"
else
    echo "bad"
fi
```

Also on the bottom of https://docs.shopware.com/en/shopware-6-en/first-steps/system-requirements there is the intended node dependency provided like `node-js version 12 to 16 `.