### PR TITLE
pin npm version to ^9.0.0

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -11,6 +11,7 @@ RUN \
       curl -fsSL https://deb.nodesource.com/setup_16.x | bash; \
   elif echo "${SHOPWARE_VERSION}" | grep -q '^v6.5.*'; then \
       curl -fsSL https://deb.nodesource.com/setup_18.x | bash; \
+      npm install -g npm@^9.0.0 \
   elif echo "${SHOPWARE_VERSION}" | grep -q '^v6.6.*'; then \
       curl -fsSL https://deb.nodesource.com/setup_20.x | bash; \
   else \


### PR DESCRIPTION
Node ^18.0 installs npm ^10.0 which is not suitable for the administration build:

> npm ERR! engine Not compatible with your version of node/npm: administration@1.0.0
> npm ERR! notsup Required: {"node":"^18.0.0","npm":"^8.0.0 || ^9.0.0"}
> npm ERR! notsup Actual:   {"npm":"10.2.3","node":"v18.19.0"}
