### PR TITLE
Update shopware versions

### DIFF
--- a/.github/workflows/build-docker-images.yaml
+++ b/.github/workflows/build-docker-images.yaml
@@ -231,7 +231,7 @@ jobs:
             php-version: "8.1"
             flavour: alpine
             template: https://github.com/shopware/shopware
-          - shopware-version: v6.5.8.13
+          - shopware-version: v6.5.8.15
             php-version: "8.1"
             flavour: alpine
             template: https://github.com/shopware/shopware
@@ -399,7 +399,7 @@ jobs:
             php-version: "8.1"
             flavour: debian
             template: https://github.com/shopware/shopware
-          - shopware-version: v6.5.8.13
+          - shopware-version: v6.5.8.15
             php-version: "8.1"
             flavour: debian
             template: https://github.com/shopware/shopware


### PR DESCRIPTION
This PR adds/bumps the following Showpare Versions: 

- `new` 6.6.8.1
- `bumped` 6.6.7.0 -> 6.6.7.1
- `bumped` 6.5.8.13 -> 6.5.8.15