### PR TITLE
chore: Add Shopware versions 6.6.9 and 6.6.10

### DIFF
--- a/.github/workflows/build-docker-images.yaml
+++ b/.github/workflows/build-docker-images.yaml
@@ -267,7 +267,15 @@ jobs:
             php-version: "8.3"
             flavour: alpine
             template: https://github.com/shopware/shopware
-          - shopware-version: v6.6.8.1
+          - shopware-version: v6.6.8.2
+            php-version: "8.3"
+            flavour: alpine
+            template: https://github.com/shopware/shopware
+          - shopware-version: v6.6.9.0
+            php-version: "8.3"
+            flavour: alpine
+            template: https://github.com/shopware/shopware
+          - shopware-version: v6.6.10.2
             php-version: "8.3"
             flavour: alpine
             template: https://github.com/shopware/shopware
@@ -435,7 +443,15 @@ jobs:
             php-version: "8.3"
             flavour: debian
             template: https://github.com/shopware/shopware
-          - shopware-version: v6.6.8.1
+          - shopware-version: v6.6.8.2
+            php-version: "8.3"
+            flavour: debian
+            template: https://github.com/shopware/shopware
+          - shopware-version: v6.6.9.0
+            php-version: "8.3"
+            flavour: debian
+            template: https://github.com/shopware/shopware
+          - shopware-version: v6.6.10.2
             php-version: "8.3"
             flavour: debian
             template: https://github.com/shopware/shopware


### PR DESCRIPTION
- Updating 6.6.8.1 to 6.6.8.2
- Adding 6.6.9.0
- Adding 6.6.10.2